### PR TITLE
Fix ATH-M50x preset

### DIFF
--- a/presets/Audio Technica ATH-M50x.txt
+++ b/presets/Audio Technica ATH-M50x.txt
@@ -1,11 +1,11 @@
-Preamp: -2,9 dB
-Filter 1: ON LS Fc 90 Hz Gain 2,8 dB Q 0,9
-Filter 2: ON PK Fc 200 Hz Gain -3,3 dB Q 0,9
-Filter 3: ON PK Fc 290 Hz Gain 4,5 dB Q 1,8
-Filter 4: ON PK Fc 2800 Hz Gain -3,7 dB Q 1,5
-Filter 5: ON PK Fc 3670 Hz Gain 2,7 dB Q 4,5
-Filter 6: ON PK Fc 4340 Hz Gain -5,0 dB Q 4,5
-Filter 7: ON PK Fc 5800 Hz Gain 2,8 dB Q 3,5
-Filter 8: ON PK Fc 7000 Hz Gain -3,0 dB Q 6,0
-Filter 9: ON PK Fc 8100 Hz Gain -4,6 dB Q 5,0
-Filter 10: ON HS Fc 11000 Hz Gain -10,0 dB Q 0,8
+Preamp: -4.7 dB
+Filter  1: ON PK Fc    40 Hz Gain -3.6 dB Q 0.5
+Filter  2: ON LS Fc   105 Hz Gain  5.5 dB Q 0.71
+Filter  3: ON PK Fc   170 Hz Gain -3.9 dB Q 1.0
+Filter  4: ON PK Fc   335 Hz Gain  5.0 dB Q 1.4
+Filter  5: ON PK Fc  1550 Hz Gain  1.5 dB Q 1.2
+Filter  6: ON PK Fc  2600 Hz Gain -1.1 dB Q 1.6
+Filter  7: ON PK Fc  4350 Hz Gain -5.0 dB Q 4.0
+Filter  8: ON PK Fc  5300 Hz Gain  5.5 dB Q 1.0
+Filter  9: ON PK Fc  5650 Hz Gain -3.0 dB Q 4.0
+Filter 10: ON HS Fc 10000 Hz Gain -1.0 dB Q 0.71


### PR DESCRIPTION
Resolves #1 

Also replaced commas with periods since those are what the [APO wiki](https://sourceforge.net/p/equalizerapo/wiki/Configuration%20reference/) specifies and Easyeffects doesn't properly load presets using commas.